### PR TITLE
fix: add write permission to GITHUB_TOKEN used in github workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for Maven publishing. It grants the workflow write permissions to repository contents, which is required for certain publishing steps.